### PR TITLE
Add CircleCI Slack notifications for master builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,3 +60,8 @@ workflows:
               only:
                 - master
                 - /v\d+\.\d+/
+
+notify:
+  webhooks:
+    - url: https://webhooks.convoy.com/hook/circleci/edd5647d0574923ab03cf138830453dbe7dde6aa/slack-author-on-failure?branches=master,
+    - url: https://webhooks.convoy.com/hook/circleci/edd5647d0574923ab03cf138830453dbe7dde6aa/slack-author-on-deploy?deploy_job_name=release


### PR DESCRIPTION
# Add CircleCI Slack notifications for master
_Migration: `2019-09-11-add-circle-build-notifications`_

This repo was missing one or more [failure/success notification hooks](https://github.com/convoyinc/donvoy-service/blob/master/docs/webhooks/circleci.md) that we thought might be useful. These notifications happen via [Donvoy](https://github.com/convoyinc/donvoy-service), the Infrastructure Team's webhook glue service.

## Changes
* ADD: a failure notification for branch 'master'
* ADD: a success notification for job 'release'


# Next steps

**If you approve of this change**: Please merge the PR yourself, it will be unmonitored otherwise.

**If you don't like this change**: You can close this PR; but please comment on why this change should _not_ be applied.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖